### PR TITLE
feat(cli): add env-manager-decrypt CLI v0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,48 @@ node dist/app.js
 
 ---
 
+## CLI: Decrypt .env Files
+
+The `env-manager-decrypt` CLI reverses `env-manager-encrypt`, restoring a dotenvx-compatible encrypted `.env` file to plaintext.
+
+### Usage
+
+```bash
+npx env-manager-decrypt <file> [--env <name>] [--key <hex>] [-o <outfile>]
+```
+
+| Argument | Description |
+|----------|-------------|
+| `<file>` | Path to the encrypted `.env` file |
+| `--env <name>` | Environment name. Reads `DOTENV_PRIVATE_KEY_<NAME>` from `.env.keys`. |
+| `--key <hex>` | Private key hex string. Skips `.env.keys` lookup entirely. |
+| `-o, --output <file>` | Write decrypted output to this file instead of overwriting the input. |
+
+### What It Does
+
+1. Reads the private key from a colocated `.env.keys` file (or `--key`).
+2. Decrypts all `encrypted:` prefixed values using ECIES.
+3. Strips `DOTENV_PUBLIC_KEY` and the dotenvx header from the output.
+4. Writes the plaintext `.env` back (or to `-o` if specified).
+
+### Examples
+
+```bash
+# Decrypt in place (reads private key from .env.keys automatically)
+npx env-manager-decrypt .env
+
+# Decrypt using an environment-specific key
+npx env-manager-decrypt .env --env development
+
+# Decrypt to a separate file, keeping the encrypted file intact
+npx env-manager-decrypt .env -o .env.plain
+
+# Decrypt using a key provided directly
+npx env-manager-decrypt .env --key <private-key-hex>
+```
+
+---
+
 ## Validation Errors
 
 `load()` aggregates all validation issues into a single `ConfigValidationError` rather than failing on the first problem. This lets you see all missing or invalid variables at once.

--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "type": "module",
   "bin": {
-    "env-manager-encrypt": "./dist/encrypt.js"
+    "env-manager-encrypt": "./dist/encrypt.js",
+    "env-manager-decrypt": "./dist/decrypt.js"
   },
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",

--- a/src/cli/decrypt.ts
+++ b/src/cli/decrypt.ts
@@ -1,0 +1,163 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+import { PrivateKey, decrypt } from 'eciesjs';
+
+export interface DecryptOptions {
+  /** Path to the encrypted .env file */
+  filePath: string;
+  /** Hex private key — if omitted, read from colocated .env.keys */
+  privateKeyHex?: string;
+  /** Write decrypted output here instead of overwriting the input file */
+  outputPath?: string;
+}
+
+export interface DecryptResult {
+  decryptedCount: number;
+  skippedCount: number;
+}
+
+function loadPrivateKeyFromKeysFile(envFilePath: string, envName?: string): string {
+  const keysFilePath = path.join(path.dirname(envFilePath), '.env.keys');
+  if (!fs.existsSync(keysFilePath)) {
+    throw new Error(`.env.keys not found at ${keysFilePath}. Provide a key with --key.`);
+  }
+  const parsed = dotenv.parse(fs.readFileSync(keysFilePath));
+  if (envName != null && envName !== '') {
+    const normalized = envName.toUpperCase().replace(/[^A-Z0-9]+/g, '_');
+    const varName = `DOTENV_PRIVATE_KEY_${normalized}`;
+    const key = parsed[varName];
+    if (!key) throw new Error(`${varName} not found in .env.keys`);
+    return key;
+  }
+  const key = parsed['DOTENV_PRIVATE_KEY'];
+  if (!key) throw new Error('DOTENV_PRIVATE_KEY not found in .env.keys');
+  return key;
+}
+
+/**
+ * Decrypt all `encrypted:` prefixed values in a dotenvx-compatible .env file,
+ * restoring the original plaintext values.
+ *
+ * Behavior:
+ * - Reads the private key from .env.keys unless --key is provided.
+ * - Strips the DOTENV_PUBLIC_KEY line from the output.
+ * - Strips the dotenvx header comment block from the output.
+ * - Skips values not prefixed with `encrypted:`.
+ * - Writes plaintext to outputPath (or overwrites the input file).
+ */
+export async function decryptDotenvFile(options: DecryptOptions, envName?: string): Promise<DecryptResult> {
+  const { filePath, outputPath } = options;
+  let { privateKeyHex } = options;
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`File not found: ${filePath}`);
+  }
+
+  const raw = fs.readFileSync(filePath);
+  const parsed = dotenv.parse(raw);
+
+  if (!privateKeyHex) {
+    privateKeyHex = loadPrivateKeyFromKeysFile(filePath, envName);
+  }
+
+  const privateKeyBuf = Buffer.from(privateKeyHex, 'hex');
+
+  let decryptedCount = 0;
+  let skippedCount = 0;
+
+  const decryptedEntries: Record<string, string> = {};
+  for (const [k, value] of Object.entries(parsed)) {
+    if (k === 'DOTENV_PUBLIC_KEY') {
+      // Strip from output — no longer needed after decryption
+      continue;
+    }
+    if (value.startsWith('encrypted:')) {
+      const cipherB64 = value.slice('encrypted:'.length);
+      const cipherBuf = Buffer.from(cipherB64, 'base64');
+      const plaintext = Buffer.from(decrypt(privateKeyBuf, cipherBuf)).toString('utf8');
+      decryptedEntries[k] = plaintext;
+      decryptedCount++;
+    } else {
+      decryptedEntries[k] = value;
+      skippedCount++;
+    }
+  }
+
+  const bodyLines = Object.entries(decryptedEntries)
+    .map(([k, v]) => `${k}="${v}"`)
+    .join('\n');
+  const envContent = bodyLines + '\n';
+
+  const effectiveOutputPath = outputPath ?? filePath;
+  fs.writeFileSync(effectiveOutputPath, envContent, 'utf8');
+
+  return { decryptedCount, skippedCount };
+}
+
+function printUsage(): void {
+  console.log(`Usage: env-manager-decrypt <file> [options]
+
+Decrypt a dotenvx-compatible encrypted .env file back to plaintext.
+
+Arguments:
+  file               Path to the encrypted .env file
+
+Options:
+  --env <name>       Environment name (reads DOTENV_PRIVATE_KEY_<NAME> from .env.keys)
+  --key <hex>        Private key hex (skips .env.keys lookup)
+  -o, --output <file>  Write decrypted output to this file instead of overwriting the input
+  --help             Show this help message`);
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  if (args.includes('--help') || args.length === 0) {
+    printUsage();
+    process.exit(args.includes('--help') ? 0 : 1);
+    return;
+  }
+
+  let filePath: string | undefined;
+  let env: string | undefined;
+  let privateKeyHex: string | undefined;
+  let outputPath: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--env' && i + 1 < args.length) {
+      env = args[++i];
+    } else if (args[i] === '--key' && i + 1 < args.length) {
+      privateKeyHex = args[++i];
+    } else if ((args[i] === '-o' || args[i] === '--output') && i + 1 < args.length) {
+      outputPath = args[++i];
+    } else if (!args[i].startsWith('--') && !args[i].startsWith('-')) {
+      filePath = args[i];
+    }
+  }
+
+  if (!filePath) {
+    console.error('Error: No file path provided');
+    printUsage();
+    process.exit(1);
+    return;
+  }
+
+  try {
+    const result = await decryptDotenvFile({ filePath, privateKeyHex, outputPath }, env);
+    console.log(`Decrypted ${result.decryptedCount} value(s), skipped ${result.skippedCount} plaintext value(s)`);
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+}
+
+const isMain = process.argv[1] != null && (
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1].endsWith('/env-manager-decrypt') ||
+  process.argv[1].endsWith('\\env-manager-decrypt')
+);
+
+if (isMain) {
+  main();
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -16,4 +16,11 @@ export default defineConfig([
     banner: { js: '#!/usr/bin/env node' },
     clean: false,
   },
+  {
+    entry: ['src/cli/decrypt.ts'],
+    format: ['esm'],
+    target: 'es2022',
+    banner: { js: '#!/usr/bin/env node' },
+    clean: false,
+  },
 ]);


### PR DESCRIPTION
## Summary

- Adds `npx env-manager-decrypt` CLI to reverse `env-manager-encrypt`
- Reads private key from colocated `.env.keys` or `--key <hex>` flag
- Supports `--env <name>` for environment-specific keys and `-o` for non-destructive output
- Strips `DOTENV_PUBLIC_KEY` and dotenvx header from decrypted output
- Updates README with full decrypt CLI docs
- Bumps version to `0.2.3`

## Test plan

- [x] All 157 existing tests passing
- [x] `tsup` build succeeds — `dist/decrypt.js` generated
- [x] `env-manager-decrypt` registered in `package.json` bin

🤖 Generated with [Claude Code](https://claude.com/claude-code)