### PR TITLE
docs: cross-reference Python version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,6 +751,10 @@ npm run typecheck    # tsc --noEmit
 npm run build        # multi-entry build: library (ESM + CJS) + CLI to dist/
 ```
 
+## Related Projects
+
+Looking for a Python version? Check out **[env-manager](https://github.com/NotoriosTI/env-manager)** — the original Python implementation with full feature parity. Both projects share the same YAML config format, secret resolution logic, and API design, so you can use whichever fits your stack.
+
 ## License
 
 ISC


### PR DESCRIPTION
## Summary
- Adds a "Related Projects" section to README linking to [env-manager](https://github.com/NotoriosTI/env-manager)
- Notes full feature parity and shared YAML config format between both implementations

## Test plan
- [ ] Verify the link resolves correctly
- [ ] Confirm section renders properly in GitHub markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)