### PR TITLE
feat: add origin aliases (JS parity with Python v0.2.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "",
   "type": "module",
   "bin": {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,5 +1,15 @@
 import type { EncryptedDotenvConfig, EnvironmentConfig, PrivateKeyConfig } from './types.js';
 
+export const ORIGIN_ALIASES: Record<string, 'local' | 'gcp'> = {
+  dotenv:               'local',
+  'env-file':           'local',
+  '.env':               'local',
+  'gcp-secretmanager':  'gcp',
+  'gcp-secret-manager': 'gcp',
+  secretmanager:        'gcp',
+};
+export const CANONICAL_ORIGINS = new Set<string>(['local', 'gcp']);
+
 type ConfigMap = Record<string, unknown>;
 
 function isConfigMap(value: unknown): value is ConfigMap {
@@ -39,11 +49,12 @@ export function parseEnvironments(
       );
     }
 
-    const origin = rawOrigin.toLowerCase();
+    const rawLower = rawOrigin.toLowerCase();
+    const origin = (ORIGIN_ALIASES[rawLower] ?? rawLower) as 'local' | 'gcp';
 
-    if (origin !== 'local' && origin !== 'gcp') {
+    if (!CANONICAL_ORIGINS.has(origin)) {
       throw new Error(
-        `Invalid origin '${rawOrigin}' in environment '${name}'. Must be 'local' or 'gcp'`,
+        `Invalid origin '${rawOrigin}' in environment '${name}'. Must be 'local' or 'gcp' (or an alias)`,
       );
     }
 

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,6 +1,7 @@
 import type { SecretLoader, SourceContext } from './types.js';
 import { DotEnvLoader } from './loaders/dotenv.js';
 import { GCPSecretLoader } from './loaders/gcp.js';
+import { ORIGIN_ALIASES } from './environment.js';
 
 export interface LoaderFactoryContext
   extends Pick<SourceContext, 'secretOrigin' | 'gcpProjectId' | 'dotenvPath'> {}
@@ -9,7 +10,8 @@ const loaderCache = new Map<string, SecretLoader>();
 
 export function createLoader(context: LoaderFactoryContext): SecretLoader {
   const { secretOrigin, gcpProjectId, dotenvPath } = context;
-  const normalizedOrigin = (secretOrigin ?? '').toLowerCase();
+  const rawOrigin = (secretOrigin ?? '').toLowerCase();
+  const normalizedOrigin = ORIGIN_ALIASES[rawOrigin] ?? rawOrigin;
   const cacheKey = `${normalizedOrigin}:${gcpProjectId ?? ''}:${dotenvPath ?? ''}`;
 
   if (loaderCache.has(cacheKey)) {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -13,7 +13,7 @@ import type {
   ValidationConfig,
   VariableDefinition,
 } from './types.js';
-import { parseEnvironments } from './environment.js';
+import { CANONICAL_ORIGINS, ORIGIN_ALIASES, parseEnvironments } from './environment.js';
 import { NotImplementedError } from './errors.js';
 import { _resetLoaderCache, createLoader } from './factory.js';
 import { DotEnvLoader } from './loaders/dotenv.js';
@@ -248,10 +248,13 @@ export class ConfigManager {
           `Unknown environment '${varDef.environment}' referenced by variable '${varName}'`,
         );
       }
-      const originOverride = varDef.secretOrigin ?? varDef.origin;
-      if (originOverride != null && originOverride !== 'local' && originOverride !== 'gcp') {
+      const rawOverride = varDef.secretOrigin ?? varDef.origin;
+      const originOverride = rawOverride != null
+        ? ((ORIGIN_ALIASES[rawOverride.toLowerCase()] ?? rawOverride.toLowerCase()) as SecretOrigin)
+        : null;
+      if (originOverride != null && !CANONICAL_ORIGINS.has(originOverride)) {
         throw new Error(
-          `Invalid secret_origin '${originOverride}' for variable '${varName}'. Must be 'local' or 'gcp'`,
+          `Invalid secret_origin '${rawOverride}' for variable '${varName}'. Must be 'local' or 'gcp' (or an alias)`,
         );
       }
     }
@@ -369,9 +372,12 @@ export class ConfigManager {
     }
 
     // Apply origin override (secretOrigin or origin key)
-    const originOverride = varDef.secretOrigin ?? varDef.origin;
+    const rawOriginOverride = varDef.secretOrigin ?? varDef.origin;
+    const originOverride = rawOriginOverride != null
+      ? (ORIGIN_ALIASES[rawOriginOverride.toLowerCase()] ?? rawOriginOverride.toLowerCase()) as SecretOrigin
+      : null;
     if (originOverride != null) {
-      const origin = originOverride as SecretOrigin;
+      const origin = originOverride;
       ctx = { ...ctx, secretOrigin: origin };
       if (origin === 'gcp') {
         // GCP origin: dotenvPath is always null (dotenv is irrelevant for GCP secrets)

--- a/tests/environment-integration.test.ts
+++ b/tests/environment-integration.test.ts
@@ -346,7 +346,7 @@ describe('TestEnvironmentSelection', () => {
       );
 
       expect(() => new ConfigManager(configPath)).toThrow(
-        "Invalid secret_origin 'vault' for variable 'payment_token'. Must be 'local' or 'gcp'",
+        "Invalid secret_origin 'vault' for variable 'payment_token'. Must be 'local' or 'gcp' (or an alias)",
       );
     } finally {
       cleanupTempDir(repoRoot);
@@ -826,6 +826,75 @@ describe('TestSingletonWithEnvironments', () => {
           dotenvPath: '.env.override',
         }),
       ).resolves.not.toThrow();
+    } finally {
+      cleanupTempDir(repoRoot);
+    }
+  });
+});
+
+describe('OriginAliasesIntegration', () => {
+  it('variable with secret_origin alias "dotenv" routes to local loader', async () => {
+    const repoRoot = createTempDir();
+    try {
+      const configPath = writeRepoConfig(
+        repoRoot,
+        `
+        environments:
+          development:
+            origin: local
+            default: true
+        variables:
+          API_KEY:
+            source: API_KEY
+            type: str
+            required: true
+            secret_origin: dotenv
+        `,
+      );
+      writeEnv(repoRoot, 'API_KEY=alias-value\n');
+
+      const manager = new ConfigManager(configPath);
+      await manager.load();
+
+      // Alias 'dotenv' normalized to 'local' — variable loads from the .env file
+      expect(manager.get('API_KEY')).toBe('alias-value');
+    } finally {
+      cleanupTempDir(repoRoot);
+    }
+  });
+
+  it('variable with secret_origin alias "gcp-secretmanager" routes to gcp loader', async () => {
+    const repoRoot = createTempDir();
+    try {
+      const configPath = writeRepoConfig(
+        repoRoot,
+        `
+        environments:
+          production:
+            origin: gcp
+            gcp_project_id: prod-project
+            default: true
+        variables:
+          DB_PASSWORD:
+            source: DB_PASSWORD
+            type: str
+            required: true
+            secret_origin: gcp-secretmanager
+        `,
+      );
+      const fakeLoader = {
+        get: vi.fn().mockResolvedValue('secret-value'),
+        getMany: vi.fn().mockResolvedValue({ DB_PASSWORD: 'secret-value' }),
+      };
+      vi.spyOn(factory, 'createLoader').mockReturnValue(fakeLoader as never);
+
+      const manager = new ConfigManager(configPath);
+      await manager.load();
+
+      expect(factory.createLoader).toHaveBeenCalledWith(
+        expect.objectContaining({ secretOrigin: 'gcp', dotenvPath: null }),
+      );
+      expect(manager.get('DB_PASSWORD')).toBe('secret-value');
     } finally {
       cleanupTempDir(repoRoot);
     }

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseEnvironments } from '../src/environment.js';
+import { CANONICAL_ORIGINS, ORIGIN_ALIASES, parseEnvironments } from '../src/environment.js';
 
 describe('parseEnvironments', () => {
   it('returns empty object when no environments key', () => {
@@ -62,7 +62,34 @@ describe('parseEnvironments', () => {
           },
         },
       }),
-    ).toThrow("Invalid origin 'vault' in environment 'staging'. Must be 'local' or 'gcp'");
+    ).toThrow("Invalid origin 'vault' in environment 'staging'. Must be 'local' or 'gcp' (or an alias)");
+  });
+
+  it.each(['dotenv', 'env-file', '.env'])('alias %s resolves to local', (alias) => {
+    const environments = parseEnvironments({
+      environments: {
+        dev: { origin: alias },
+      },
+    });
+    expect(environments.dev.origin).toBe('local');
+  });
+
+  it.each(['gcp-secretmanager', 'gcp-secret-manager', 'secretmanager'])(
+    'alias %s resolves to gcp',
+    (alias) => {
+      const environments = parseEnvironments({
+        environments: {
+          prod: { origin: alias, gcp_project_id: 'my-project' },
+        },
+      });
+      expect(environments.prod.origin).toBe('gcp');
+    },
+  );
+
+  it('all ORIGIN_ALIASES values are canonical origins', () => {
+    for (const target of Object.values(ORIGIN_ALIASES)) {
+      expect(CANONICAL_ORIGINS.has(target)).toBe(true);
+    }
   });
 
   it('local origin defaults dotenv_path to ".env"', () => {


### PR DESCRIPTION
## Summary
- Adds origin aliases so users can write `dotenv`, `env-file`, or `.env` instead of `local`, and `gcp-secretmanager`, `gcp-secret-manager`, or `secretmanager` instead of `gcp`
- Normalization applied at all three resolution sites: `environment.ts` (config parsing), `factory.ts` (loader cache key), `manager.ts` (per-variable override — both validation and apply paths)
- Exports `ORIGIN_ALIASES` and `CANONICAL_ORIGINS` for downstream use and structural testing
- Bumps version `0.2.4` → `0.2.5`

## Test plan
- [x] All existing tests pass (166 passed, 7 skipped)
- [x] 6 alias resolution tests in `environment.test.ts` (3 local aliases, 3 gcp aliases)
- [x] Structural guard: all `ORIGIN_ALIASES` values are in `CANONICAL_ORIGINS`
- [x] 2 manager-level integration tests verifying alias normalization end-to-end
- [x] Error messages updated to include "(or an alias)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)